### PR TITLE
release: v1.0.45

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -139,16 +139,16 @@
         },
         {
             "name": "wp-content-framework/controller",
-            "version": "v1.0.45",
+            "version": "v1.0.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-content-framework/controller.git",
-                "reference": "770106fa8d13631551c7d76101a5e02ec8176591"
+                "reference": "1806d880b1e3dfb2922b38bbb7d25b11b6455f56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-content-framework/controller/zipball/770106fa8d13631551c7d76101a5e02ec8176591",
-                "reference": "770106fa8d13631551c7d76101a5e02ec8176591",
+                "url": "https://api.github.com/repos/wp-content-framework/controller/zipball/1806d880b1e3dfb2922b38bbb7d25b11b6455f56",
+                "reference": "1806d880b1e3dfb2922b38bbb7d25b11b6455f56",
                 "shasum": ""
             },
             "require": {
@@ -182,7 +182,7 @@
             ],
             "support": {
                 "issues": "https://github.com/wp-content-framework/controller/issues",
-                "source": "https://github.com/wp-content-framework/controller/tree/v1.0.45"
+                "source": "https://github.com/wp-content-framework/controller/tree/v1.0.46"
             },
             "funding": [
                 {
@@ -190,7 +190,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2021-03-14T08:57:16+00:00"
+            "time": "2021-03-20T14:18:00+00:00"
         },
         {
             "name": "wp-content-framework/presenter",


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update dependencies (96a7a0cee9c48fdd34009a4283a1b26e9e0e3cc6)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/wp-content-framework/api/tree/master)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>composer prepare</em></summary>

```Shell
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/php-compatibility,../../phpcompatibility/phpcompatibility-paragonie,../../phpcompatibility/phpcompatibility-wp,../../wp-coding-standards/wpcs

>> Copy files.
>>>> phpmd.xml
>>>> phpcs.xml
```

### stderr:

```Shell
> mkdir -p ./fixtures/.git
> chmod -R +w ./fixtures/.git && rm -rdf ./fixtures
> rm -f ./phpcs.xml ./phpmd.xml ./phpunit.xml
> git clone --depth=1 https://github.com/wp-content-framework/fixtures.git fixtures
Cloning into 'fixtures'...
> WORKSPACE=${WORKSPACE:-$(cd $(dirname $0); pwd)} bash ./fixtures/bin/prepare.sh
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^0.7.1 for dealerdirect/phpcodesniffer-composer-installer
Using version ^2.9 for phpmd/phpmd
Using version ^3.5 for squizlabs/php_codesniffer
Using version ^2.3 for wp-coding-standards/wpcs
Using version ^2.1 for phpcompatibility/phpcompatibility-wp
./composer.json has been updated
Running composer update dealerdirect/phpcodesniffer-composer-installer phpmd/phpmd squizlabs/php_codesniffer wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp
Loading composer repositories with package information
Updating dependencies
Lock file operations: 22 installs, 0 updates, 0 removals
  - Locking composer/xdebug-handler (1.4.5)
  - Locking dealerdirect/phpcodesniffer-composer-installer (v0.7.1)
  - Locking matthiasmullie/minify (1.3.66)
  - Locking matthiasmullie/path-converter (1.1.3)
  - Locking pdepend/pdepend (2.9.0)
  - Locking phpcompatibility/php-compatibility (9.3.5)
  - Locking phpcompatibility/phpcompatibility-paragonie (1.3.1)
  - Locking phpcompatibility/phpcompatibility-wp (2.1.1)
  - Locking phpmd/phpmd (2.9.1)
  - Locking psr/container (1.1.1)
  - Locking psr/log (1.1.3)
  - Locking squizlabs/php_codesniffer (3.5.8)
  - Locking symfony/config (v5.2.4)
  - Locking symfony/dependency-injection (v5.2.5)
  - Locking symfony/deprecation-contracts (v2.2.0)
  - Locking symfony/filesystem (v5.2.4)
  - Locking symfony/polyfill-ctype (v1.22.1)
  - Locking symfony/polyfill-php80 (v1.22.1)
  - Locking symfony/service-contracts (v2.2.0)
  - Locking wp-coding-standards/wpcs (2.3.0)
  - Locking wp-content-framework/controller (v1.0.46)
  - Locking wp-content-framework/presenter (v1.0.36)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 22 installs, 0 updates, 0 removals
  - Downloading squizlabs/php_codesniffer (3.5.8)
  - Downloading dealerdirect/phpcodesniffer-composer-installer (v0.7.1)
  - Downloading matthiasmullie/path-converter (1.1.3)
  - Downloading phpcompatibility/php-compatibility (9.3.5)
  - Downloading phpcompatibility/phpcompatibility-paragonie (1.3.1)
  - Downloading phpcompatibility/phpcompatibility-wp (2.1.1)
  - Downloading symfony/polyfill-ctype (v1.22.1)
  - Downloading symfony/filesystem (v5.2.4)
  - Downloading psr/container (1.1.1)
  - Downloading symfony/service-contracts (v2.2.0)
  - Downloading symfony/polyfill-php80 (v1.22.1)
  - Downloading symfony/deprecation-contracts (v2.2.0)
  - Downloading symfony/dependency-injection (v5.2.5)
  - Downloading symfony/config (v5.2.4)
  - Downloading pdepend/pdepend (2.9.0)
  - Downloading psr/log (1.1.3)
  - Downloading composer/xdebug-handler (1.4.5)
  - Downloading phpmd/phpmd (2.9.1)
  - Downloading wp-coding-standards/wpcs (2.3.0)
  - Downloading matthiasmullie/minify (1.3.66)
  - Downloading wp-content-framework/presenter (v1.0.36)
  - Downloading wp-content-framework/controller (v1.0.46)
  0/22 [>---------------------------]   0%
 16/22 [====================>-------]  72%
 21/22 [==========================>-]  95%
 22/22 [============================] 100%  - Installing squizlabs/php_codesniffer (3.5.8): Extracting archive
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.7.1): Extracting archive
  - Installing matthiasmullie/path-converter (1.1.3): Extracting archive
  - Installing phpcompatibility/php-compatibility (9.3.5): Extracting archive
  - Installing phpcompatibility/phpcompatibility-paragonie (1.3.1): Extracting archive
  - Installing phpcompatibility/phpcompatibility-wp (2.1.1): Extracting archive
  - Installing symfony/polyfill-ctype (v1.22.1): Extracting archive
  - Installing symfony/filesystem (v5.2.4): Extracting archive
  - Installing psr/container (1.1.1): Extracting archive
  - Installing symfony/service-contracts (v2.2.0): Extracting archive
  - Installing symfony/polyfill-php80 (v1.22.1): Extracting archive
  - Installing symfony/deprecation-contracts (v2.2.0): Extracting archive
  - Installing symfony/dependency-injection (v5.2.5): Extracting archive
  - Installing symfony/config (v5.2.4): Extracting archive
  - Installing pdepend/pdepend (2.9.0): Extracting archive
  - Installing psr/log (1.1.3): Extracting archive
  - Installing composer/xdebug-handler (1.4.5): Extracting archive
  - Installing phpmd/phpmd (2.9.1): Extracting archive
  - Installing wp-coding-standards/wpcs (2.3.0): Extracting archive
  - Installing matthiasmullie/minify (1.3.66): Extracting archive
  - Installing wp-content-framework/presenter (v1.0.36): Extracting archive
  - Installing wp-content-framework/controller (v1.0.46): Extracting archive
  0/10 [>---------------------------]   0%
 10/10 [============================] 100%
 10/10 [============================] 100%9 package suggestions were added by new dependencies, use `composer suggest` to see details.
Generating autoload files
13 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^1.0 for wp-content-framework/controller
./composer.json has been updated
Running composer update wp-content-framework/controller
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
Generating autoload files
13 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Nothing to install, update or remove
Generating autoload files
13 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

</details>
<details>
<summary><em>composer packages</em></summary>

```Shell
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/php-compatibility,../../phpcompatibility/phpcompatibility-paragonie,../../phpcompatibility/phpcompatibility-wp,../../wp-coding-standards/wpcs
```

### stderr:

```Shell
> WORKSPACE=${WORKSPACE:-$(cd $(dirname $0); pwd)} bash ./fixtures/bin/packages.sh
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^0.7.1 for dealerdirect/phpcodesniffer-composer-installer
Using version ^2.9 for phpmd/phpmd
Using version ^3.5 for squizlabs/php_codesniffer
Using version ^2.3 for wp-coding-standards/wpcs
Using version ^2.1 for phpcompatibility/phpcompatibility-wp
./composer.json has been updated
Running composer update dealerdirect/phpcodesniffer-composer-installer phpmd/phpmd squizlabs/php_codesniffer wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp
Loading composer repositories with package information
Updating dependencies
Lock file operations: 22 installs, 0 updates, 0 removals
  - Locking composer/xdebug-handler (1.4.5)
  - Locking dealerdirect/phpcodesniffer-composer-installer (v0.7.1)
  - Locking matthiasmullie/minify (1.3.66)
  - Locking matthiasmullie/path-converter (1.1.3)
  - Locking pdepend/pdepend (2.9.0)
  - Locking phpcompatibility/php-compatibility (9.3.5)
  - Locking phpcompatibility/phpcompatibility-paragonie (1.3.1)
  - Locking phpcompatibility/phpcompatibility-wp (2.1.1)
  - Locking phpmd/phpmd (2.9.1)
  - Locking psr/container (1.1.1)
  - Locking psr/log (1.1.3)
  - Locking squizlabs/php_codesniffer (3.5.8)
  - Locking symfony/config (v5.2.4)
  - Locking symfony/dependency-injection (v5.2.5)
  - Locking symfony/deprecation-contracts (v2.2.0)
  - Locking symfony/filesystem (v5.2.4)
  - Locking symfony/polyfill-ctype (v1.22.1)
  - Locking symfony/polyfill-php80 (v1.22.1)
  - Locking symfony/service-contracts (v2.2.0)
  - Locking wp-coding-standards/wpcs (2.3.0)
  - Locking wp-content-framework/controller (v1.0.46)
  - Locking wp-content-framework/presenter (v1.0.36)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 22 installs, 0 updates, 0 removals
    0 [>---------------------------]    0 [>---------------------------]    0 [>---------------------------]  - Installing squizlabs/php_codesniffer (3.5.8): Extracting archive
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.7.1): Extracting archive
  - Installing matthiasmullie/path-converter (1.1.3): Extracting archive
  - Installing phpcompatibility/php-compatibility (9.3.5): Extracting archive
  - Installing phpcompatibility/phpcompatibility-paragonie (1.3.1): Extracting archive
  - Installing phpcompatibility/phpcompatibility-wp (2.1.1): Extracting archive
  - Installing symfony/polyfill-ctype (v1.22.1): Extracting archive
  - Installing symfony/filesystem (v5.2.4): Extracting archive
  - Installing psr/container (1.1.1): Extracting archive
  - Installing symfony/service-contracts (v2.2.0): Extracting archive
  - Installing symfony/polyfill-php80 (v1.22.1): Extracting archive
  - Installing symfony/deprecation-contracts (v2.2.0): Extracting archive
  - Installing symfony/dependency-injection (v5.2.5): Extracting archive
  - Installing symfony/config (v5.2.4): Extracting archive
  - Installing pdepend/pdepend (2.9.0): Extracting archive
  - Installing psr/log (1.1.3): Extracting archive
  - Installing composer/xdebug-handler (1.4.5): Extracting archive
  - Installing phpmd/phpmd (2.9.1): Extracting archive
  - Installing wp-coding-standards/wpcs (2.3.0): Extracting archive
  - Installing matthiasmullie/minify (1.3.66): Extracting archive
  - Installing wp-content-framework/presenter (v1.0.36): Extracting archive
  - Installing wp-content-framework/controller (v1.0.46): Extracting archive
  0/10 [>---------------------------]   0%
  9/10 [=========================>--]  90%
 10/10 [============================] 100%9 package suggestions were added by new dependencies, use `composer suggest` to see details.
Generating autoload files
13 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^1.0 for wp-content-framework/controller
./composer.json has been updated
Running composer update wp-content-framework/controller
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
Generating autoload files
13 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- composer.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)